### PR TITLE
fix: prebuild support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+pnpm-lock.yaml
+npm-lock.json
+yarn.lock

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var y = require('./build/Release/yencode.node');
+var y = require('node-gyp-build')(__dirname);
 
 var toBuffer = Buffer.alloc ? Buffer.from : Buffer;
 var allocBuffer = (Buffer.allocUnsafe || Buffer);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yencode",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "SIMD accelerated yEnc encoder/decoder and CRC32 calculator",
   "keywords": [
     "yenc",
@@ -18,12 +18,20 @@
     "node": ">=0.10"
   },
   "scripts": {
-    "install": "node-gyp rebuild"
+    "install": "node-gyp-build",
+    "prebuild": "prebuildify --napi --strip",
+    "prebuild-ia32": "prebuildify --napi --strip --arch=ia32"
   },
   "gypfile": true,
   "type": "commonjs",
   "bugs": {
     "url": "https://github.com/animetosho/node-yencode/issues"
+  },
+  "dependencies": {
+    "node-gyp-build": "^4.2.0"
+  },
+  "devDependencies": {
+    "prebuildify": "^6.0.1"
   },
   "homepage": "https://animetosho.org/app/node-yencode"
 }


### PR DESCRIPTION
I'm attempting to run this library on electron, to do that the package needs to define a "prebuild" command, however to be honest I'm loosing my shit, as even with these changes the lib works fine on NodeJS but still emits a "fatal error" on electron

the way electron handles this is quite simple, it just runs the prebuild command with specific configs, and this is the first native library I used that doesn't work on electron, and errors when calling any of the methods in the library

to rebuild this library electron simply does `electron-rebuild -f -w yencode`, which uses the `@electron/rebuild` library.

I honestly just want help with this, because this is the only functional yencode library in the world, but it simply refuses to work on electron